### PR TITLE
COMP: Fix configuration against ITK>=5.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
 
 project(AirwaySegmentation)
 


### PR DESCRIPTION
Update CMake minimum required version to match Slicer requirement and fix the following error:

```
CMake Error at /work/Preview/Slicer-0-build/ITK-build/ITKConfig.cmake:90 (if):
  if given arguments:

    "ITK_FIND_REQUIRED_ITKIOImageBase" "OR" "M" "IN_LIST" "ITK_MODULES_ENABLED"

  Unknown arguments specified
Call Stack (most recent call first):
  AirwaySegmentationCLI/CMakeLists.txt:22 (find_package)
```